### PR TITLE
Relocated executable logic into `bin` file

### DIFF
--- a/beautify-with-words.js
+++ b/beautify-with-words.js
@@ -1,114 +1,67 @@
-#!/usr/bin/env node
-
 'use strict';
 
-var fs = require('fs');
 var phonetic = require('phonetic');
 var UglifyJS = require('uglify-js');
 
-var argv = require('optimist')
-  .usage('Beautify javascript with unique \"long-ish words\" for variable names.\n' +
-         'https://github.com/zertosh/beautify-with-words\n\n' +
-         'Usage $0 [input_file.js] [options]\n\n' +
-         'If input file is omitted, then input will be read from STDIN.')
-  .alias('b', 'beautify')
-  .alias('o', 'output')
-  .alias('h', 'help')
-  .describe('b', 'Option to pass to UglifyJS2\'s beautifier. (https://github.com/mishoo/UglifyJS2#beautifier-options).')
-  .describe('o', 'Output file (default STDOUT).')
-  .describe('h', 'This help.')
-  .check(function(argv) {
-    if (argv._.length > 1) throw 'Error: too many filenames.';
-    if (argv.h) throw '';
-  })
-  .argv;
+module.exports = function beautifyWithWords (contents, argv) {
 
-
-// Default options to pass to the beautifier
-var beautifyOptions = {
-  beautify: true
-};
-
-
-// Format options to pass to the beautifier
-if (argv.b) {
-  Array.isArray(argv.b) || (argv.b = [ argv.b ]);
-  argv.b.forEach(function(option) {
-    if (typeof option !== 'string') return;
-    option = option.split('=');
-    option[0] = option[0].replace(/-/g, '_');
-    option[1] = option[1] === 'true'  ? true :
-                option[1] === 'false' ? false :
-                option[1] === 'null'  ? null :
-                !isNaN(option[1])     ? parseInt(option[1]) :
-                                        option[1];
-    beautifyOptions[option[0]] = option[1];
-  });
-}
-
-
-// Generate unique phonetic words to be used for variable names.
-// Start with 2 syllable words, once we've somewhat exhausted that
-// space, try 3 syllable words, and so on.
-var getUniqueWord = (function() {
-  var options = { capFirst: false, syllables: 2 };
-  var used = {};
-  var keyCount = 0;
-  return function generate() {
-    var word = phonetic.generate(options);
-    if (!used[word]) {
-      used[word] = true;
-      return word;
-    }
-    var currKeyCount = Object.keys(used).length;
-    if (currKeyCount === keyCount) {
-      keyCount = 0;
-      options.syllables++;
-    } else {
-      keyCount = currKeyCount;
-    }
-    return generate();
+  // Default options to pass to the beautifier
+  var beautifyOptions = {
+    beautify: true
   };
-})();
 
-
-// Override `next_mangled` so it returns our words instead.
-// mangle_names() -> mangle() -> next_mangled() in
-// https://github.com/mishoo/UglifyJS2/blob/v2.4.11/lib/scope.js
-UglifyJS.AST_Scope.prototype.next_mangled = function() {
-  var next;
-  while ((next = getUniqueWord())) {
-    if (!UglifyJS.is_identifier(next)) continue;
-    return next;
+  // Format options to pass to the beautifier
+  if (argv.b) {
+    Array.isArray(argv.b) || (argv.b = [ argv.b ]);
+    argv.b.forEach(function(option) {
+      if (typeof option !== 'string') return;
+      option = option.split('=');
+      option[0] = option[0].replace(/-/g, '_');
+      option[1] = option[1] === 'true'  ? true :
+                  option[1] === 'false' ? false :
+                  option[1] === 'null'  ? null :
+                  !isNaN(option[1])     ? parseInt(option[1]) :
+                                          option[1];
+      beautifyOptions[option[0]] = option[1];
+    });
   }
-};
+
+  // Generate unique phonetic words to be used for variable names.
+  // Start with 2 syllable words, once we've somewhat exhausted that
+  // space, try 3 syllable words, and so on.
+  var getUniqueWord = (function() {
+    var options = { capFirst: false, syllables: 2 };
+    var used = {};
+    var keyCount = 0;
+    return function generate() {
+      var word = phonetic.generate(options);
+      if (!used[word]) {
+        used[word] = true;
+        return word;
+      }
+      var currKeyCount = Object.keys(used).length;
+      if (currKeyCount === keyCount) {
+        keyCount = 0;
+        options.syllables++;
+      } else {
+        keyCount = currKeyCount;
+      }
+      return generate();
+    };
+  })();
 
 
-// Read contents
-var contents = '';
-if (argv._.length === 0) {
-  // Read from STDIN
-  process.stdin.setEncoding('utf8');
-  process.stdin.resume();
-  process.stdin.on('data', function (buf) {
-      contents += buf.toString();
-  });
-  process.stdin.on('close', function () {
-      processContents(contents);
-  });
-} else {
-  // Read from file
-  try {
-    contents = fs.readFileSync(argv._[0], { encoding: 'utf8' });
-    processContents(contents);
-  } catch(e) {
-    console.error('Failed to open file "%s."', argv._[0]);
-    process.exit(1);
-  }
-}
+  // Override `next_mangled` so it returns our words instead.
+  // mangle_names() -> mangle() -> next_mangled() in
+  // https://github.com/mishoo/UglifyJS2/blob/v2.4.11/lib/scope.js
+  UglifyJS.AST_Scope.prototype.next_mangled = function() {
+    var next;
+    while ((next = getUniqueWord())) {
+      if (!UglifyJS.is_identifier(next)) continue;
+      return next;
+    }
+  };
 
-
-function processContents(contents) {
   // "Mangle" names
   var ast;
   try {
@@ -116,25 +69,12 @@ function processContents(contents) {
     ast.figure_out_scope();
     ast.mangle_names();
   } catch(err) {
-    console.error('Error: %s\nLine: %d\nCol: %d', err.message, err.line, err.col);
-    process.exit(1);
+    throw err;
   }
 
   // Beautify
   var stream = UglifyJS.OutputStream(beautifyOptions);
   ast.print(stream);
 
-  // Output
-  if (typeof argv.o === 'string') {
-    // Write to file
-    try {
-      fs.writeFileSync(argv.o, stream.toString(), { encoding: 'utf8' });
-    } catch(e) {
-      console.error('Failed to write to file "%s."', argv.o);
-      process.exit(1);
-    }
-  } else {
-    // Write to STDOUT
-    console.log( stream.toString() );
-  }
-}
+  return stream.toString();
+};

--- a/bin/beautify-with-words
+++ b/bin/beautify-with-words
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+'use strict';
+
+var fs = require('fs');
+var beautifyWithWords = require('../');
+
+var argv = require('optimist')
+  .usage('Beautify javascript with unique \"long-ish words\" for variable names.\n' +
+         'https://github.com/zertosh/beautify-with-words\n\n' +
+         'Usage $0 [input_file.js] [options]\n\n' +
+         'If input file is omitted, then input will be read from STDIN.')
+  .alias('b', 'beautify')
+  .alias('o', 'output')
+  .alias('h', 'help')
+  .describe('b', 'Option to pass to UglifyJS2\'s beautifier. (https://github.com/mishoo/UglifyJS2#beautifier-options).')
+  .describe('o', 'Output file (default STDOUT).')
+  .describe('h', 'This help.')
+  .check(function(argv) {
+    if (argv._.length > 1) throw 'Error: too many filenames.';
+    if (argv.h) throw '';
+  })
+  .argv;
+
+// Read contents
+var contents = '';
+if (argv._.length === 0) {
+  // Read from STDIN
+  process.stdin.setEncoding('utf8');
+  process.stdin.resume();
+  process.stdin.on('data', function (buf) {
+      contents += buf.toString();
+  });
+  process.stdin.on('close', function () {
+      processContents(contents);
+  });
+} else {
+  // Read from file
+  try {
+    contents = fs.readFileSync(argv._[0], { encoding: 'utf8' });
+    processContents(contents);
+  } catch(e) {
+    console.error('Failed to open file "%s."', argv._[0]);
+    process.exit(1);
+  }
+}
+
+function processContents(contents) {
+  var stream = beautifyWithWords(contents, argv);
+
+  // Output
+  if (typeof argv.o === 'string') {
+    // Write to file
+    try {
+      fs.writeFileSync(argv.o, stream.toString(), { encoding: 'utf8' });
+    } catch(e) {
+      console.error('Failed to write to file "%s."', argv.o);
+      process.exit(1);
+    }
+  } else {
+    // Write to STDOUT
+    console.log( stream.toString() );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "homepage": "https://github.com/zertosh/beautify-with-words",
   "main": "./beautify-with-words.js",
   "bin": {
-    "beautify-with-words": "./beautify-with-words.js"
+    "beautify-with-words": "bin/beautify-with-words"
   },
   "author": "Andres Suarez <zertosh@gmail.com>",
   "bugs": "https://github.com/zertosh/beautify-with-words/issues",
@@ -27,6 +27,5 @@
   },
   "engines": {
     "node": ">=0.8.0"
-  },
-  "preferGlobal": true
+  }
 }


### PR DESCRIPTION
As mentioned in #3, the current library is unusable as a dependency. This PR removes the CLI specific logic to a separate `bin` file.

Ideally, there would be a test suite to test against but I did not know what your preferred testing framework was.

Fixes #3.
